### PR TITLE
docs: update examples to read better

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,11 @@ Convert markdown lists into ASCII trees.
 For example, if you run:
 
 ```bash
-echo -e "- a\n- b\n - ba" | mdtree
+cat <<EOF | mdtree
+- a
+- b
+  - ba
+EOF
 ```
 
 It will output:
@@ -25,7 +29,11 @@ You can also customize the tree style with `--style`, and change the root
 element with `--root`, for example:
 
 ```bash
-$ echo -e "- foo\n- bar\n  - hi" | mdtree --root ⁜ --style rounded
+cat <<EOF | mdtree --root ⁜ --style rounded
+- foo
+- bar
+  - hi
+EOF
 ```
 
 Resulting in:


### PR DESCRIPTION
This PR updates the README examples to use heredoc syntax instead of echo commands. This makes the examples clearer and more readable, as it shows the exact input structure without escape characters.